### PR TITLE
emit `id_token`s when we refresh tokens.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,20 +1,6 @@
 language: node_js
 node_js:
-  - "0.10"
-  - "0.11"
+  - "8.9.3"
 
 before_install:
   - npm install -g grunt-cli
-
-notifications:
-  email:
-    recipients:
-      - andris@kreata.ee
-    on_success: change
-    on_failure: change
-  webhooks:
-    urls:
-      - https://webhooks.gitter.im/e/0ed18fd9b3e529b3c2cc
-    on_success: change  # options: [always|never|change] default: always
-    on_failure: always  # options: [always|never|change] default: always
-    on_start: false     # default: false

--- a/package.json
+++ b/package.json
@@ -25,6 +25,7 @@
     "grunt": "*",
     "grunt-contrib-jshint": "*",
     "grunt-mocha-test": "*",
+    "mocha": "^6.1.4",
     "sinon": "*"
   }
 }

--- a/src/xoauth2.js
+++ b/src/xoauth2.js
@@ -84,7 +84,7 @@ XOAuth2Generator.prototype.getToken = function(callback) {
  * @param {String} accessToken New access token
  * @param {Number} timeout Access token lifetime in seconds
  *
- * Emits 'token': { user: User email-address, accessToken: the new accessToken, timeout: TTL in seconds}
+ * Emits 'token': { user: User email-address, accessToken: the new accessToken, timeout: TTL in seconds, idToken: the new idToken}
  */
 XOAuth2Generator.prototype.updateToken = function(accessToken, timeout, idToken) {
     this.token = this.buildXOAuth2Token(accessToken);

--- a/test/server.js
+++ b/test/server.js
@@ -35,6 +35,8 @@ OAuthServer.prototype.addUser = function(username, refreshToken) {
 OAuthServer.prototype.generateAccessToken = function(refreshToken) {
     var username = this.tokens[refreshToken];
     var accessToken = crypto.randomBytes(10).toString('base64');
+    // Hardcode for testing.
+    const idToken = username === 'userwithoutidtoken@example.com' ? undefined : crypto.randomBytes(10).toString('base64');
 
     if (!username) {
         return {
@@ -44,15 +46,17 @@ OAuthServer.prototype.generateAccessToken = function(refreshToken) {
 
     this.users[username].accessToken = accessToken;
     this.users[username].expiresIn = Date.now + this.options.expiresIn * 1000;
+    this.users[username].idToken = idToken;
 
     if (this.options.onUpdate) {
-        this.options.onUpdate(username, accessToken);
+        this.options.onUpdate(username, accessToken, idToken);
     }
 
     return {
         access_token: accessToken,
         expires_in: this.options.expiresIn,
-        token_type: 'Bearer'
+        token_type: 'Bearer',
+        id_token: idToken
     };
 };
 


### PR DESCRIPTION
## Changes made

When we make the request to `https://accounts.google.com/o/oauth2/token` to
refresh a user’s tokens, emit the refreshed id token that comes back as well,
such that consumers of this API can keep both those values in sync.